### PR TITLE
Restricts "spawn_digimon" to bot owner.

### DIFF
--- a/digicord.py
+++ b/digicord.py
@@ -181,7 +181,7 @@ class Digicord(commands.Cog):
 
 
     @commands.guild_only()
-    @commands.admin()
+    @commands.is_owner()
     @admin.command(name="spawn_digimon")
     async def command_spawn_digimon(self, ctx: commands.Context):
         await self.spawn_digimon(ctx)


### PR DESCRIPTION
Allowing any server admin to do this is just asking for trouble. 
Closes #29 